### PR TITLE
Default to working directory when setting cache folder

### DIFF
--- a/R/cacheDirectories.R
+++ b/R/cacheDirectories.R
@@ -61,8 +61,8 @@ resetCacheSearchEnvironment = function() {
 }
 
 
-.setDir <- function(optname, dirpath=NULL) {
-  diropts <- list(ifelse(is.null(dirpath), getwd(), dirpath))
-  names(diropts) <- optname
+.setDir = function(optname, dirpath=NULL) {
+  diropts = list(ifelse(is.null(dirpath), getwd(), dirpath))
+  names(diropts) = optname
   do.call(options, diropts)
 }

--- a/R/cacheDirectories.R
+++ b/R/cacheDirectories.R
@@ -12,9 +12,7 @@
 #' @export
 #' @example
 #' R/examples/example.R
-setCacheDir = function(cacheDir) {
-	options(RCACHE.DIR=cacheDir)
-}
+setCacheDir = function(cacheDir=NULL) { .setDir("RCACHE.DIR", cacheDir) }
 
 #' Set shared cache directory
 #'
@@ -24,17 +22,13 @@ setCacheDir = function(cacheDir) {
 #'
 #' @param sharedCacheDir Directory where shared caches should be stored
 #' @export
-setSharedCacheDir = function(sharedCacheDir) {
-	options(RESOURCES.RCACHE=sharedCacheDir)
-}
+setSharedCacheDir = function(sharedCacheDir=NULL) { .setDir("RESOURCES.RCACHE", sharedCacheDir) }
 
 #' Sets local cache build directory with scripts for building files.
 #'
 #' @param cacheBuildDir Directory where build scripts are stored.
 #' @export
-setCacheBuildDir = function(cacheBuildDir) {
-	options(RBUILD.DIR=cacheBuildDir)
-}
+setCacheBuildDir = function(cacheBuildDir=NULL) { .setDir("RBUILD.DIR", cacheBuildDir) }
 
 #' View simpleCache options
 #'
@@ -66,3 +60,9 @@ resetCacheSearchEnvironment = function() {
 	options(SIMPLECACHE.ENV=NULL)
 }
 
+
+.setDir <- function(optname, dirpath=NULL) {
+  diropts <- list(ifelse(is.null(dirpath), getwd(), dirpath))
+  names(diropts) <- optname
+  do.call(options, diropts)
+}

--- a/tests/testthat/test_all.R
+++ b/tests/testthat/test_all.R
@@ -2,6 +2,19 @@ library(simpleCache)
 
 context("error checking")
 
+
+kSetters <- list(RCACHE.DIR=setCacheDir, RESOURCES.RCACHE=setSharedCacheDir, RBUILD.DIR=setCacheBuildDir)
+
+test_dir_default <- function(cacheDirOptname) {
+  expect_false(getwd() == getOption(cacheDirOptname))
+  test_that(sprintf("%s setter uses current folder for argument-less call", cacheDirOptname), {
+    do.call(kSetters[[cacheDirOptname]], args=list())
+    expect_equal(getwd(), getOption(cacheDirOptname))
+  })
+  resetCacheSearchEnvironment()
+}
+
+
 test_that("notifications and messages as expected", {
   
   # message if cache exists
@@ -122,6 +135,10 @@ test_that("option setting works", {
   expect_true(!grepl("cacheEnv", options_out[4]))
   
 })
+
+
+for (optname in names(kSetters)) { test_dir_default(optname) }
+
 
 test_that("objects pass through in buildEnvir", {
   

--- a/tests/testthat/test_all.R
+++ b/tests/testthat/test_all.R
@@ -4,11 +4,11 @@ context("error checking")
 
 
 # Map option name to its setter.
-kSetters <- list(RCACHE.DIR=setCacheDir, RESOURCES.RCACHE=setSharedCacheDir, RBUILD.DIR=setCacheBuildDir)
+kSetters = list(RCACHE.DIR=setCacheDir, RESOURCES.RCACHE=setSharedCacheDir, RBUILD.DIR=setCacheBuildDir)
 
 
 # Test a cache dir setting in managed context fashion, resetting before and after test.
-test_dir_default <- function(cacheDirOptname) {
+test_dir_default = function(cacheDirOptname) {
   resetCacheSearchEnvironment()
   test_that(sprintf("%s setter uses current folder for argument-less call", cacheDirOptname), {
     do.call(kSetters[[cacheDirOptname]], args=list())

--- a/tests/testthat/test_all.R
+++ b/tests/testthat/test_all.R
@@ -3,10 +3,13 @@ library(simpleCache)
 context("error checking")
 
 
+# Map option name to its setter.
 kSetters <- list(RCACHE.DIR=setCacheDir, RESOURCES.RCACHE=setSharedCacheDir, RBUILD.DIR=setCacheBuildDir)
 
+
+# Test a cache dir setting in managed context fashion, resetting before and after test.
 test_dir_default <- function(cacheDirOptname) {
-  expect_false(getwd() == getOption(cacheDirOptname))
+  resetCacheSearchEnvironment()
   test_that(sprintf("%s setter uses current folder for argument-less call", cacheDirOptname), {
     do.call(kSetters[[cacheDirOptname]], args=list())
     expect_equal(getwd(), getOption(cacheDirOptname))
@@ -137,6 +140,7 @@ test_that("option setting works", {
 })
 
 
+# Test each cache directory option setter.
 for (optname in names(kSetters)) { test_dir_default(optname) }
 
 


### PR DESCRIPTION
Default to current for setting cache directory:
I often find myself in the cache directory. While it's not a big deal to pass `getwd()` as an argument, it'd be nice to be able to simply say `setCacheDir()` and have that set `RCACHE.DIR` to the current folder.